### PR TITLE
Integrate idpf extensions into p4runtime

### DIFF
--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -38,12 +38,35 @@ proto_library(
 )
 
 proto_library(
+    name = "idpf_p4info_proto",
+    srcs = ["idpf/p4info.proto"],
+    deps = [
+        ":p4info_proto",
+    ],
+    # TODO(github.com/grpc/grpc/issues/20675): strip_import_prefix breaks
+    # cc_grpc_library. Make proto folder the Bazel root folder as a workaround.
+    # strip_import_prefix = "proto",
+)
+
+proto_library(
     name = "p4runtime_proto",
     srcs = ["p4/v1/p4runtime.proto"],
     deps = [
         ":p4data_proto",
         ":p4info_proto",
         "@com_google_googleapis//google/rpc:status_proto",
+        "@com_google_protobuf//:any_proto",
+    ],
+    # TODO(github.com/grpc/grpc/issues/20675): strip_import_prefix brakes
+    # cc_grpc_library. Make proto folder the Bazel root folder as a workaround.
+    # strip_import_prefix = "proto",
+)
+
+proto_library(
+    name = "idpf_p4runtime_proto",
+    srcs = ["idpf/p4runtime.proto"],
+    deps = [
+        ":p4runtime_proto",
         "@com_google_protobuf//:any_proto",
     ],
     # TODO(github.com/grpc/grpc/issues/20675): strip_import_prefix brakes
@@ -62,6 +85,11 @@ cc_proto_library(
 )
 
 cc_proto_library(
+    name = "idpf_p4info_cc_proto",
+    deps = [":idpf_p4info_proto"],
+)
+
+cc_proto_library(
     name = "p4data_cc_proto",
     deps = [":p4data_proto"],
 )
@@ -69,6 +97,11 @@ cc_proto_library(
 cc_proto_library(
     name = "p4runtime_cc_proto",
     deps = [":p4runtime_proto"],
+)
+
+cc_proto_library(
+    name = "idpf_p4runtime_cc_proto",
+    deps = [":idpf_p4runtime_proto"],
 )
 
 py_proto_library(
@@ -82,6 +115,11 @@ py_proto_library(
 )
 
 py_proto_library(
+    name = "idpf_p4info_py_proto",
+    deps = [":idpf_p4info_proto"],
+)
+
+py_proto_library(
     name = "p4data_py_proto",
     deps = [":p4data_proto"],
 )
@@ -89,6 +127,20 @@ py_proto_library(
 py_proto_library(
     name = "p4runtime_py_proto",
     deps = [":p4runtime_proto"],
+)
+
+py_proto_library(
+    name = "idpf_p4runtime_py_proto",
+    deps = [":idpf_p4runtime_proto"],
+)
+
+go_proto_library(
+    name = "idpf_p4info_go_proto",
+    importpath = "github.com/p4lang/p4runtime/go/idpf",
+    protos = [
+        ":idpf_p4info_proto",
+        ":idpf_p4runtime_proto",
+    ],
 )
 
 go_proto_library(

--- a/proto/idpf/p4info.proto
+++ b/proto/idpf/p4info.proto
@@ -18,6 +18,9 @@ syntax = "proto3";
 
 import "p4/config/v1/p4info.proto";
 
+// This is an extension of p4/config/v1/p4info.proto.
+// It provides support for the meter externs in the Intel IPU E2100.
+
 package idpf;
 
 option go_package = "github.com/p4lang/p4runtime/go/idpf";

--- a/proto/idpf/p4info.proto
+++ b/proto/idpf/p4info.proto
@@ -20,6 +20,8 @@ import "p4/config/v1/p4info.proto";
 
 package idpf;
 
+option go_package = "github.com/p4lang/p4runtime/go/idpf";
+
 message P4Ids {
   enum Prefix {
     UNSPECIFIED = 0;

--- a/proto/idpf/p4info.proto
+++ b/proto/idpf/p4info.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+
+import "p4/config/v1/p4info.proto";
+
+package idpf;
+
+message P4Ids {
+  enum Prefix {
+    UNSPECIFIED = 0;
+    MATCH_VALUE_LOOKUP_TABLE = 0x81;
+    TERNARY_MATCH_LOOKUP_TABLE = 0x82;
+    TSMETER = 0x83;
+    DIRECT_TSMETER = 0x84;
+    PACKET_MOD_METER = 0x85;
+    DIRECT_PACKET_MOD_METER = 0x86;
+  }
+}
+
+message Param {
+  uint32 id = 1;
+  string name = 2;
+  uint32 bitwidth = 3;
+}
+
+message MatchValueLookupTable {
+  p4.config.v1.Preamble preamble = 1;
+  repeated p4.config.v1.MatchField match_fields = 2;
+  repeated Param params = 3;
+  uint32 size = 4;
+}
+
+message TSMeter {
+  p4.config.v1.Preamble preamble = 1;
+  p4.config.v1.MeterSpec spec = 2;
+  int32 size = 3;
+  uint32 index_width = 4;
+}
+
+message DirectTSMeter {
+  p4.config.v1.Preamble preamble = 1;
+  p4.config.v1.MeterSpec spec = 2;
+}
+
+message PacketModMeter {
+  p4.config.v1.Preamble preamble = 1;
+  p4.config.v1.MeterSpec spec = 2;
+  int32 size = 3;
+  uint32 index_width = 4;
+}
+
+message DirectPacketModMeter {
+  p4.config.v1.Preamble preamble = 1;
+  p4.config.v1.MeterSpec spec = 2;
+}

--- a/proto/idpf/p4info.proto
+++ b/proto/idpf/p4info.proto
@@ -1,3 +1,19 @@
+// Copyright (c) 2024, Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// For licensing information, see the file ‘LICENSE’ in the root folder
+
 syntax = "proto3";
 
 import "p4/config/v1/p4info.proto";

--- a/proto/idpf/p4runtime.proto
+++ b/proto/idpf/p4runtime.proto
@@ -23,6 +23,8 @@ import "p4/v1/p4runtime.proto";
 
 package idpf;
 
+option go_package = "github.com/p4lang/p4runtime/go/idpf";
+
 // MatchValueLookupTable
 message MVLUTEntry {
   uint32 mvlut_id = 1;

--- a/proto/idpf/p4runtime.proto
+++ b/proto/idpf/p4runtime.proto
@@ -1,0 +1,58 @@
+// Copyright (c) 2016, Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//***************************************************************************
+// Copyright(c) 2018 Intel Corporation
+//
+// For licensing information, see the file ‘LICENSE’ in the root folder
+//***************************************************************************
+
+syntax = "proto3";
+
+import "google/protobuf/any.proto";
+import "p4/v1/p4runtime.proto";
+
+// This is an extension of p4/v1/p4runtime.proto
+
+package idpf;
+
+// MatchValueLookupTable
+message MVLUTEntry {
+  uint32 mvlut_id = 1;
+  message ConfigParam {
+    message Param {
+      uint32 param_id = 1;
+      uint64 param_value = 2;
+    }
+    repeated Param params = 1;
+  }
+  repeated p4.v1.FieldMatch match = 2;
+  ConfigParam param = 3;
+}
+
+// DANGER -- this is an extension of p4.v1.Action with some additional fields.
+// as such it needs to be identical to that with just extra stuff added.
+// It is unfortunate that protobuf does not support versioning and extension.
+message Action {
+  uint32 action_id = 1;
+  message Param {
+    uint32 param_id = 2;
+    bytes value = 3;
+    // extra stuff added for idpf
+    string param_name = 5;
+    string proto_id = 6;
+    string key_name = 7;
+  }
+  repeated Param params = 4;
+}

--- a/proto/idpf/p4runtime.proto
+++ b/proto/idpf/p4runtime.proto
@@ -20,6 +20,7 @@ import "google/protobuf/any.proto";
 import "p4/v1/p4runtime.proto";
 
 // This is an extension of p4/v1/p4runtime.proto
+// It provides support for the meter externs in the Intel IPU E2100.
 
 package idpf;
 

--- a/proto/idpf/p4runtime.proto
+++ b/proto/idpf/p4runtime.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Google Inc.
+// Copyright (c) 2024, Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,12 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-//***************************************************************************
-// Copyright(c) 2018 Intel Corporation
 //
 // For licensing information, see the file ‘LICENSE’ in the root folder
-//***************************************************************************
 
 syntax = "proto3";
 

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -411,15 +411,3 @@ message Digest {
   Preamble preamble = 1;
   P4DataTypeSpec type_spec = 2;
 }
-
-message PacketModMeter {
-  Preamble preamble = 1;
-  MeterSpec spec = 2;
-  int32 size = 3;
-  uint32 index_width = 4;
-}
-
-message DirectPacketModMeter {
-  Preamble preamble = 1;
-  MeterSpec spec = 2;
-}


### PR DESCRIPTION
The IPDK fork of the p4runtime repository includes ES2K-specific changes to `p4runtime.proto` and `p4info.proto`. These extensions support the `PacketModMeter` and `DirectPacketModMeter` externs.

This CL moves the changes from the standard protobuf files to a separate `idpf` package.

Associated PRs: https://github.com/ipdk-io/networking-recipe/pull/428 and https://github.com/ipdk-io/stratum-dev/pull/209.